### PR TITLE
Add one additional worker

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -50,6 +50,7 @@ function build() {
   git clone --depth 1 --branch openssl-3.1.3 https://github.com/openssl/openssl.git
   pushd openssl
   ./Configure $OPENSSL_ARCH --prefix=$deps
+  make -j$CMAKE_BUILD_PARALLEL_LEVEL
   make -j$CMAKE_BUILD_PARALLEL_LEVEL install_sw
   popd
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export CMAKE_BUILD_PARALLEL_LEVEL=`nproc`
+export CMAKE_BUILD_PARALLEL_LEVEL=$((`nproc`+1))
 
 OS_ARCH=""
 CMAKE_ARCH=""
@@ -50,8 +50,7 @@ function build() {
   git clone --depth 1 --branch openssl-3.1.3 https://github.com/openssl/openssl.git
   pushd openssl
   ./Configure $OPENSSL_ARCH --prefix=$deps
-  make -j$(nproc)
-  make -j$(nproc) install_sw
+  make -j$CMAKE_BUILD_PARALLEL_LEVEL install_sw
   popd
 
   git clone --depth 1 --branch libssh2-1.11.0 https://github.com/libssh2/libssh2.git


### PR DESCRIPTION
Generally a best practice because workers can get blocked waiting for I/O and we want to keep the CPU busy.

Also don't run make twice to build then install OpenSSL, just directly do the install and only build what it needs.